### PR TITLE
Change pkg name from y0ssar1an/q to ryboe/q

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # q
-[![CircleCI](https://circleci.com/gh/y0ssar1an/q/tree/master.svg?style=svg)](https://circleci.com/gh/y0ssar1an/q/tree/master)
-[![GoDoc](https://godoc.org/github.com/y0ssar1an/q?status.svg)](https://godoc.org/github.com/y0ssar1an/q)
-[![Go Report Card](https://goreportcard.com/badge/github.com/y0ssar1an/q)](https://goreportcard.com/report/github.com/y0ssar1an/q)
+
+[![CircleCI](https://circleci.com/gh/ryboe/q/tree/master.svg?style=svg)](https://circleci.com/gh/ryboe/q/tree/master)
+[![GoDoc](https://godoc.org/github.com/ryboe/q?status.svg)](https://godoc.org/github.com/ryboe/q)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ryboe/q)](https://goreportcard.com/report/github.com/ryboe/q)
 
 q is a better way to do print statement debugging.
 
@@ -20,7 +21,7 @@ Type `q.Q` instead of `fmt.Printf` and your variables will be printed like this:
 ## Basic Usage
 
 ```go
-import "github.com/y0ssar1an/q"
+import "q"
 ...
 q.Q(a, b, c)
 ```
@@ -28,12 +29,14 @@ q.Q(a, b, c)
 For best results, dedicate a terminal to tailing `$TMPDIR/q` while you work.
 
 ## Install
+
 ```sh
-go get -u github.com/y0ssar1an/q
+git clone https://github.com/ryboe/q $GOPATH/src/q
 ```
 
 Put these functions in your shell config. Typing `qq` or `rmqq` will then start
 tailing `$TMPDIR/q`.
+
 ```sh
 qq() {
     clear
@@ -64,22 +67,11 @@ rmqq() {
 
 You also can simply `tail -f $TMPDIR/q`, but it's highly recommended to use the above commands.
 
-If you add a symbolic link to the package via
-```sh
-ln -s $GOPATH/src/github.com/y0ssar1an/q/ $GOPATH/src/q
-```
-
-you can import the package via
-```go
-import (
-	"q"
-)
-```
-
 ## Editor Integration
 
-#### VS Code
+### VS Code
 `Preferences > User Snippets > Go`
+
 ```json
 "qq": {
     "prefix": "qq",
@@ -88,8 +80,10 @@ import (
 }
 ```
 
-#### Sublime Text
+### Sublime Text
+
 `Tools > Developer > New Snippet`
+
 ```xml
 <snippet>
     <content><![CDATA[
@@ -100,8 +94,10 @@ q.Q($1) // DEBUG
 </snippet>
 ```
 
-#### Atom
+### Atom
+
 `Atom > Open Your Snippets`
+
 ```coffee
 '.source.go':
     'qq':
@@ -109,20 +105,24 @@ q.Q($1) // DEBUG
         'body': 'q.Q($1) // DEBUG'
 ```
 
-#### JetBrains GoLand
+### JetBrains GoLand
+
 `Settings > Editor > Live Templates`
 
 In `Go`, add a new template with:
-- Abbreviation: `qq`
-- Description: `Pretty-print to $TMPDIR/q`
-- Template text: `q.Q($END$) // DEBUG`
-- Applicable in: select the `Go` scope
 
-#### Emacs
+* Abbreviation: `qq`
+* Description: `Pretty-print to $TMPDIR/q`
+* Template text: `q.Q($END$) // DEBUG`
+* Applicable in: select the `Go` scope
+
+### Emacs
+
 Add a new snippet file to the go-mode snippets directory
 (`$HOME/.emacs.d/snippets/go-mode/qq`). This should
 contain:
-```
+
+```emacs
 # -*- mode: snippet -*-
 # name: qq
 # key: qq
@@ -130,10 +130,12 @@ contain:
 q.Q(${1:...}) // DEBUG
 ```
 
-#### vim
+### vim
+
 TBD Send me a PR, please :)
 
 ## Haven't I seen this somewhere before?
+
 Python programmers will recognize this as a Golang port of the
 [`q` module by zestyping](https://github.com/zestyping/q).
 
@@ -145,7 +147,9 @@ PyCon 2013. Watch it! It's funny :)
 ## FAQ
 
 ### Why `q.Q`?
+
 It's quick to type and unlikely to cause naming collisions.
 
 ### Is `q.Q()` safe for concurrent use?
+
 Yes.

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@ fmt.Printf("%#v", whatever). The output will be colorized and nicely formatted.
 The output goes to $TMPDIR/q, away from the noise of stdout.
 
 q exports a single Q() function. This is how you use it:
-    import "github.com/y0ssar1an/q"
+    import "q"
     ...
     q.Q(a, b, c)
 */

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
-module github.com/y0ssar1an/q
+module github.com/ryboe/q
 
 go 1.14
 
-require github.com/kr/pretty v0.2.0
+require (
+	github.com/kr/pretty v0.2.0
+	github.com/kr/text v0.2.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=

--- a/testdata/sample1.go
+++ b/testdata/sample1.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/y0ssar1an/q"
+import "q"
 
 func main() {
 	a := 123

--- a/vendor/github.com/kr/text/go.mod
+++ b/vendor/github.com/kr/text/go.mod
@@ -1,3 +1,3 @@
 module "github.com/kr/text"
 
-require "github.com/kr/pty" v1.1.1
+require "github.com/creack/pty" v1.1.9

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,6 @@
 # github.com/kr/pretty v0.2.0
 ## explicit
 github.com/kr/pretty
-# github.com/kr/text v0.1.0
+# github.com/kr/text v0.2.0
+## explicit
 github.com/kr/text


### PR DESCRIPTION
Resolve #54. It's annoying to type y0ssar1an.
Update README. Replace full github import with just `import "q"`
Vendor `github.com/kr/text`, which `go mod tidy` wants now for some reason.