### PR TITLE
Update golangci-lint v1.24 -> v1.27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.24-alpine
+      - image: golangci/golangci-lint:v1.27-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@ linters:
   enable-all: true
   disable:
     - gomnd
+    - testpackage
+    - nolintlint
     - wsl
 
 linters-settings:

--- a/args.go
+++ b/args.go
@@ -56,7 +56,7 @@ func argNames(filename string, line int) ([]string, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filename, nil, 0)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse %q: %v", filename, err)
+		return nil, fmt.Errorf("failed to parse %q: %w", filename, err)
 	}
 
 	var names []string
@@ -141,7 +141,11 @@ func getCallerInfo() (funcName, file string, line int, err error) {
 	const callDepth = 2 // user code calls q.Q() which calls std.log().
 	pc, file, line, ok := runtime.Caller(callDepth)
 	if !ok {
-		return "", "", 0, errors.New("failed to get info about the function calling q.Q")
+		// This error is not exported. It is only used internally in the q
+		// package. The error message isn't even used by the caller. So, I've
+		// suppressed the goerr113 linter here, which catches nonidiomatic
+		// error handling post Go 1.13 errors.
+		return "", "", 0, errors.New("failed to get info about the function calling q.Q") // nolint: goerr113
 	}
 
 	funcName = runtime.FuncForPC(pc).Name()

--- a/args_test.go
+++ b/args_test.go
@@ -429,7 +429,7 @@ func TestArgWidth(t *testing.T) {
 	}
 }
 
-// TestFormatArgs verifies that formatArgs() produces the expected
+// TestFormatArgs verifies that formatArgs() produces the expected string.
 func TestFormatArgs(t *testing.T) {
 	testCases := []struct {
 		id   int

--- a/logger.go
+++ b/logger.go
@@ -75,7 +75,7 @@ func (l *logger) flush() (err error) {
 	path := filepath.Join(os.TempDir(), "q")
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
-		return fmt.Errorf("failed to open %q: %v", path, err)
+		return fmt.Errorf("failed to open %q: %w", path, err)
 	}
 	defer func() {
 		if cerr := f.Close(); err == nil {
@@ -87,7 +87,7 @@ func (l *logger) flush() (err error) {
 	_, err = io.Copy(f, &l.buf)
 	l.buf.Reset()
 	if err != nil {
-		return fmt.Errorf("failed to flush q buffer: %v", err)
+		return fmt.Errorf("failed to flush q buffer: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Change some wrapped errors to use `%w` instead of `%v`.
Disable `testpackage` linter, because whitebox testing should be allowed.