### PR TITLE
Update golangci-lint v1.27.0 -> v1.28.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.27-alpine
+      - image: golangci/golangci-lint:v1.28-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/logger.go
+++ b/logger.go
@@ -73,7 +73,7 @@ func (l *logger) shouldPrintHeader(funcName, file string) bool {
 // flush writes the logger's buffer to disk.
 func (l *logger) flush() (err error) {
 	path := filepath.Join(os.TempDir(), "q")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to open %q: %w", path, err)
 	}


### PR DESCRIPTION
Format `logger.go` with `gofumports`. This nit was flagged by the updated linter. `logger.go` now uses Go's new octal literal syntax, e.g. `0o600` instead of `0600`.