### PR TITLE
Clean up go.mod and go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/ryboe/q
 
 go 1.14
 
-require (
-	github.com/kr/pretty v0.2.0
-	github.com/kr/text v0.2.0 // indirect
-)
+require github.com/kr/pretty v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,5 @@
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=

--- a/vendor/github.com/kr/text/go.mod
+++ b/vendor/github.com/kr/text/go.mod
@@ -1,3 +1,3 @@
 module "github.com/kr/text"
 
-require "github.com/creack/pty" v1.1.9
+require "github.com/kr/pty" v1.1.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,5 @@
 # github.com/kr/pretty v0.2.0
 ## explicit
 github.com/kr/pretty
-# github.com/kr/text v0.2.0
-## explicit
+# github.com/kr/text v0.1.0
 github.com/kr/text


### PR DESCRIPTION
I think [`kr/text`](https://github.com/kr/text) added a `go.mod` file, so that removes the `// indirect` import from q's `go.mod`.