### PR TITLE
Update linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.29-alpine
+      - image: golangci/golangci-lint:v1.30-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/args.go
+++ b/args.go
@@ -81,6 +81,7 @@ func argNames(filename string, line int) ([]string, error) {
 		for _, arg := range call.Args {
 			names = append(names, argName(arg))
 		}
+
 		return true
 	})
 
@@ -103,6 +104,7 @@ func argWidth(arg string) int {
 		string(endColor), "",
 	)
 	s := replacer.Replace(arg)
+
 	return utf8.RuneCountInString(s)
 }
 
@@ -132,6 +134,7 @@ func formatArgs(args ...interface{}) []string {
 		s := colorize(pretty.Sprint(a), cyan)
 		formatted = append(formatted, s)
 	}
+
 	return formatted
 }
 
@@ -149,6 +152,7 @@ func getCallerInfo() (funcName, file string, line int, err error) {
 	}
 
 	funcName = runtime.FuncForPC(pc).Name()
+
 	return funcName, file, line, nil
 }
 
@@ -164,11 +168,13 @@ func prependArgName(names, values []string) []string {
 		}
 		if name == "" {
 			prepended[i] = value
+
 			continue
 		}
 		name = colorize(name, bold)
 		prepended[i] = fmt.Sprintf("%s=%s", name, value)
 	}
+
 	return prepended
 }
 
@@ -183,6 +189,7 @@ func isQFunction(n *ast.CallExpr) bool {
 	if !is {
 		return false
 	}
+
 	return ident.Name == "Q"
 }
 

--- a/args_test.go
+++ b/args_test.go
@@ -391,6 +391,7 @@ func TestArgNames(t *testing.T) {
 	for i := 0; i < len(got); i++ {
 		if got[i] != want[i] {
 			t.Fatalf("\ngot:  %#v\nwant: %#v", got, want)
+
 			break
 		}
 	}

--- a/logger.go
+++ b/logger.go
@@ -18,7 +18,7 @@ import (
 type color string
 
 const (
-	// ANSI color escape codes
+	// ANSI color escape codes.
 	bold     color = "\033[1m"
 	yellow   color = "\033[33m"
 	cyan     color = "\033[36m"
@@ -137,5 +137,6 @@ func (l *logger) output(args ...string) {
 func shortFile(file string) string {
 	dir := filepath.Base(filepath.Dir(file))
 	file = filepath.Base(file)
+
 	return filepath.Join(dir, file)
 }

--- a/q.go
+++ b/q.go
@@ -30,6 +30,7 @@ func Q(v ...interface{}) {
 	funcName, file, line, err := getCallerInfo()
 	if err != nil {
 		std.output(args...) // no name=value printing
+
 		return
 	}
 
@@ -45,6 +46,7 @@ func Q(v ...interface{}) {
 	names, err := argNames(file, line)
 	if err != nil {
 		std.output(args...) // no name=value printing
+
 		return
 	}
 


### PR DESCRIPTION
* bump `golangci-lint` from v1.29 -> v1.30
* Add newlines before `break`, `continue`, and `return` to make the updated linter happy