### PR TITLE
Update golangci-lint 1.30 -> 1.32

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.30-alpine
+      - image: golangci/golangci-lint:v1.32-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ run:
 linters:
   enable-all: true
   disable:
+    - exhaustivestruct
     - gomnd
     - testpackage
     - nolintlint

--- a/args.go
+++ b/args.go
@@ -124,7 +124,7 @@ func exprToString(arg ast.Expr) string {
 
 	// CallExpr will be multi-line and indented with tabs. replace tabs with
 	// spaces so we can better control formatting during output().
-	return strings.Replace(buf.String(), "\t", "    ", -1)
+	return strings.ReplaceAll(buf.String(), "\t", "    ")
 }
 
 // formatArgs converts the given args to pretty-printed, colorized strings.

--- a/logger.go
+++ b/logger.go
@@ -114,7 +114,7 @@ func (l *logger) output(args ...string) {
 
 		// Some names in name=value strings contain newlines. Insert indentation
 		// after each newline so they line up.
-		arg = strings.Replace(arg, "\n", "\n"+indent, -1)
+		arg = strings.ReplaceAll(arg, "\n", "\n"+indent)
 
 		// Break up long lines. If this is first arg printed on the line
 		// (lineArgs == 0), it makes no sense to break up the line.


### PR DESCRIPTION
* Use convencience wrapper `strings.ReplaceAll()` instead of `strings.Replace(..., -1)`. This was caught by `gocritic`.
* Disable new linter `exhaustivestruct`. It requires that all fields in a struct be set. That check is only useful in certain situations.