### PR TITLE
Enable all gocritic checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,14 @@ linters:
     - wsl
 
 linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - whyNoLint
   gocyclo:
     min-complexity: 11
   gofmt:

--- a/args.go
+++ b/args.go
@@ -60,7 +60,7 @@ func argNames(filename string, line int) ([]string, error) {
 	}
 
 	var names []string
-	ast.Inspect(f, func(n ast.Node) bool { // nolint: unparam
+	ast.Inspect(f, func(n ast.Node) bool {
 		call, is := n.(*ast.CallExpr)
 		if !is {
 			// The node is not a function call.


### PR DESCRIPTION
Enable [all the `gocritic` checks](https://go-critic.github.io/overview) except [`whyNoLint`](https://go-critic.github.io/overview#whyNoLint-ref). I tried adding explanations to a few nolints, but `gocritic` didn't recognize that an explanation had been added. It kept complaining.