### PR TITLE
Update golangci-lint 1.32 -> 1.33

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.32-alpine
+      - image: golangci/golangci-lint:v1.33-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,8 +8,9 @@ linters:
   disable:
     - exhaustivestruct
     - gomnd
-    - testpackage
     - nolintlint
+    - paralleltest # tests only take 2.5s to run. no need to parallelize
+    - testpackage
     - wsl
 
 linters-settings:
@@ -22,6 +23,6 @@ linters-settings:
     disabled-checks:
       - whyNoLint
   gocyclo:
-    min-complexity: 11
+    min-complexity: 10
   gofmt:
     simplify: true


### PR DESCRIPTION
* update `golangci-lint` v1.32.0 -> v1.33.0
* reduce `gocyclo`'s max complexity to 10, which is a nice round number