### PR TITLE
Update golangci-lint to 1.35

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.34-alpine
+      - image: golangci/golangci-lint:v1.35-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/args_test.go
+++ b/args_test.go
@@ -353,6 +353,7 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 	for _, tc := range testCases {
 		// test exprToString()
 		testName := fmt.Sprintf("exprToString(%T)", tc.arg)
+		// nolint: thelper
 		t.Run(testName, func(t *testing.T) {
 			if _, ok := tc.arg.(*ast.Ident); ok {
 				return
@@ -365,6 +366,7 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 
 		// test argName()
 		testName = fmt.Sprintf("argName(%T)", tc.arg)
+		// nolint: thelper
 		t.Run(testName, func(t *testing.T) {
 			if got := argName(tc.arg); got != tc.want {
 				t.Fatalf("\ngot:  %s\nwant: %s", got, tc.want)


### PR DESCRIPTION
* Bump `golangci-lint` v1.34 -> v1.35
* Suppress `thelper` linter in two places
  * erroneously suggested that two subtests could be test helpers