### PR TITLE
Update to Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ version: 2.1
 executors:
   go-container:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
     working_directory: /go/src/q
 
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.35-alpine
+      - image: golangci/golangci-lint:v1.37-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/ryboe/q
 
-go 1.15
+go 1.16
 
 require github.com/kr/pretty v0.2.1


### PR DESCRIPTION
* Bump the go directive in go.mod to `go 1.16`
* Bump golangci-lint 1.35.0 -> 1.36.0

I'm just waiting for the final 1.16 release to Docker Hub.