### PR TITLE
Bump golangci-lint 1.37 -> 1.41

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.37-alpine
+      - image: golangci/golangci-lint:v1.41-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,9 +8,13 @@ linters:
   disable:
     - exhaustivestruct
     - forbidigo # we need to use fmt.Print*()
+    - interfacer # deprecated
+    - golint # deprecated
     - gomnd
+    - maligned # deprecated
     - nolintlint
     - paralleltest # tests only take 2.5s to run. no need to parallelize
+    - scopelint # deprecated
     - testpackage
     - wsl
 

--- a/args_test.go
+++ b/args_test.go
@@ -349,7 +349,6 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 	}
 
 	// We can test both exprToString() and argName() with the test cases above.
-	// nolint: scopelint
 	for _, tc := range testCases {
 		// test exprToString()
 		testName := fmt.Sprintf("exprToString(%T)", tc.arg)


### PR DESCRIPTION
Disable deprecated linters:
  * golint
  * interfacer
  * maligned
  * scopelint