### PR TITLE
A more reliable way to get GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For best results, dedicate a terminal to tailing `$TMPDIR/q` while you work.
 ## Install
 
 ```sh
-git clone https://github.com/ryboe/q $GOPATH/src/q
+git clone https://github.com/ryboe/q "$(go env GOPATH)"/src/q
 ```
 
 Put these functions in your shell config. Typing `qq` or `rmqq` will then start


### PR DESCRIPTION
The GOPATH environment variable is not a sure thing anymore. https://golang.org/doc/gopath_code#GOPATH