### PR TITLE
Add devcontainer and a Dockerfile based on ryboe/archcodespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.45-alpine
+      - image: golangci/golangci-lint:v1.46-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM ryboe/archcodespace:latest
+
+ENV GOPATH="/home/vscode/go"
+ENV PATH="$GOPATH/bin:$PATH"
+
+RUN sudo pacman -Syu --noconfirm go
+
+RUN go install github.com/cweill/gotests/gotests@latest \
+    && go install github.com/fatih/gomodifytags@latest \
+    && go install github.com/josharian/impl@latest \
+    && go install github.com/haya14busa/goplay/cmd/goplay@latest \
+    && go install github.com/go-delve/delve/cmd/dlv@latest \
+    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
+    && go install golang.org/x/tools/gopls@latest \
+    && go install mvdan.cc/gofumpt@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+	"name": "Q",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+	// dlv needs these capabilities. It needs to run the ptrace (process trace)
+	// syscall, and we need to disable the default seccomp profile applied to
+	// docker containers.
+	//   https://github.com/go-delve/delve/blob/master/Documentation/faq.md#how-do-i-use-delve-with-docker
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	"settings": {
+		"go.lintTool": "golangci-lint",
+		"go.path": "/home/vscode/go",
+		"go.toolsManagement.autoUpdate": true,
+		"gopls": {
+			"formatting.gofumpt": true,
+			"ui.completion.usePlaceholders": true
+		}
+	},
+	"extensions": [
+		"davidanson.vscode-markdownlint",
+		"eamodio.gitlens",
+		"earshinov.permute-lines",
+		"github.copilot",
+		"github.vscode-pull-request-github",
+		"golang.go",
+		"ms-vsliveshare.vsliveshare",
+		"redhat.vscode-yaml",
+		"sleistner.vscode-fileutils",
+	],
+}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,12 +7,14 @@ linters:
   enable-all: true
   disable:
     - exhaustivestruct
+    - exhaustruct
     - forbidigo # we need to use fmt.Print*()
-    - interfacer # deprecated
     - golint # deprecated
     - gomnd
+    - interfacer # deprecated
     - maligned # deprecated
     - nolintlint
+    - nonamedreturns
     - paralleltest # tests only take 2.5s to run. no need to parallelize
     - scopelint # deprecated
     - testpackage


### PR DESCRIPTION
This is a first attempt to add an Arch Linux-based codespace to this repo. It includes a `devcontainer.json` file and a `Dockerfile` defining an image with a custom Go environment.