### PR TITLE
Use ryboe/alpinecodespace as a codespace base image to avoid customizations

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,23 +1,9 @@
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine AS goimage
 
-FROM mcr.microsoft.com/vscode/devcontainers/base:alpine
+FROM ghcr.io/ryboe/alpinecodespace:latest
 
 COPY --from=goimage /usr/local/go/ /usr/local/go/
-
-# dlv needs gcc and musl-dev. The rest are useful dev tools.
-RUN apk add --update fd file fzf gcc musl-dev ripgrep
-
-# Install the latest gh CLI tool. The first request fetches the URL for the
-# latest release tarball. The second request downloads the tarball.
-RUN wget --quiet --timeout=30 --output-document=- 'https://api.github.com/repos/cli/cli/releases/latest' \
-    | jq -r '.assets[] | select(.name | test("gh_.*?_linux_amd64.tar.gz")).browser_download_url' \
-    | wget --quiet --timeout=180 --input-file=- --output-document=- \
-    | sudo tar -xvz -C /usr/local/ --strip-components=1
-
-# Change vscode default shell to zsh.
-RUN sed -i 's/\/home\/vscode:\/bin\/bash/\/home\/vscode:\/bin\/zsh/' /etc/passwd
-USER vscode
 
 ENV GOPATH="/home/vscode/go"
 ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"


### PR DESCRIPTION
I moved a lot of the steps in dev container Dockerfile to a dedicated
base image called ryboe/alpinecodespace.
