### PR TITLE
Remove CI status badge from README

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,6 @@
-name: "PR"
+name: PR
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # q
 
-[![CI Status](https://github.com/ryboe/q/actions/workflows/pr.yml/badge.svg?branch=master)](https://github.com/ryboe/q/actions?query=branch%3Amaster)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ryboe/q)](https://goreportcard.com/report/github.com/ryboe/q)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/ryboe/q)](https://pkg.go.dev/github.com/ryboe/q)
 


### PR DESCRIPTION
* rename `Test` workflow to `PR`

There's no reason to run tests on `master` when the identical commit has already been tested when it was a PR (pre-merge). Also, it should be
expected that `master` always passes tests. Since only rebase merging is allowed, we can guarantee that the commit on `master` has been tested by requiring that status checks pass in the repo settings on GitHub.