### PR TITLE
Make the `runtime.Caller(CallDepth)` configurable

### DIFF
--- a/args.go
+++ b/args.go
@@ -141,8 +141,7 @@ func formatArgs(args ...interface{}) []string {
 // getCallerInfo returns the name, file, and line number of the function calling
 // q.Q().
 func getCallerInfo() (funcName, file string, line int, err error) {
-	const callDepth = 2 // user code calls q.Q() which calls std.log().
-	pc, file, line, ok := runtime.Caller(callDepth)
+	pc, file, line, ok := runtime.Caller(CallDepth)
 	if !ok {
 		// This error is not exported. It is only used internally in the q
 		// package. The error message isn't even used by the caller. So, I've

--- a/q.go
+++ b/q.go
@@ -12,6 +12,18 @@ import (
 var (
 	// std is the singleton logger.
 	std logger
+
+	// CallDepth allows setting the number of levels runtime.Caller will
+	// skip when looking up the caller of the q.Q function. This allows
+	// the `q` package to be wrapped by a project-specific wrapping function,
+	// which would increase the depth by at least one. It's better to not
+	// include calls to `q.Q` in released code at all and scrub them before,
+	// a build is created, but in some cases it might be useful to provide
+	// builds that do include the additional debug output provided by `q.Q`.
+	// This also allows the consumer of the package to control what happens
+	// with leftover `q.Q` calls. Defaults to 2, because the user code calls
+	// q.Q(), which calls getCallerInfo().
+	CallDepth = 2
 )
 
 // Q pretty-prints the given arguments to the $TMPDIR/q log file.


### PR DESCRIPTION
Being able to set the `runtime.Caller(CallDepth)` might be useful in certain use cases explained in the code comment.

For most, if not all cases, calls to `q.Q` should be removed before releasing code. One way to do this is to check for occurrences of `q.Q` in code during code review or performing static analysis. 

This change takes a slightly different approach, allowing the `CallDepth` to be set, so that wrapping code can perform checks before calling into the `q.Q` code. For example, the wrapping code could constrain usage to non-production builds, ensuring `q.Q` isn't executed when it shouldn't.

This is useful to me personally, but I can understand if it doesn't get merged.