### PR TITLE
feat: Enable gopls static analyzers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,15 @@
 				"gopls": {
 					"formatting.gofumpt": true,
 					"ui.completion.usePlaceholders": true,
+					"ui.diagnostic.analyses": {
+						"fieldalignment": true,
+						"nilness": true,
+						"unusedparams": true,
+						"unusedvariable": true,
+						"unusedwrite": true,
+						"useany": true
+					},
+					"ui.diagnostic.staticcheck": true,
 					"ui.semanticTokens": true
 				}
 			},

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,16 @@
     "go.toolsManagement.autoUpdate": true,
     "gopls": {
         "formatting.gofumpt": true,
-        "ui.completion.usePlaceholders": true
+        "ui.completion.usePlaceholders": true,
+        "ui.diagnostic.analyses": {
+            "fieldalignment": true,
+            "nilness": true,
+            "unusedparams": true,
+            "unusedvariable": true,
+            "unusedwrite": true,
+            "useany": true
+        },
+        "ui.diagnostic.staticcheck": true,
+        "ui.semanticTokens": true
     }
 }


### PR DESCRIPTION
This is the list of enabled analyzers:

    fieldalignment
    nilness
    unusedparams
    unusedvariable
    unusedwrite
    useany

The analyzers that weren't enabled have too high a risk of false positives.
