### PR TITLE
chore: update go.mod to use go 1.22

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,8 @@ jobs:
           fetch-depth: 1
       - name: Set up go
         uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Run linter
         uses: golangci/golangci-lint-action@v4
 
@@ -28,5 +30,7 @@ jobs:
           fetch-depth: 1
       - name: Set up go
         uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Run unit tests
         run: go test -v -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/ryboe/q
 
-go 1.21
+go 1.22
 
 require github.com/kr/pretty v0.3.1
 
 require (
 	github.com/kr/text v0.2.0 // indirect
-	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,5 +5,5 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
-github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,6 +4,6 @@ github.com/kr/pretty
 # github.com/kr/text v0.2.0
 ## explicit
 github.com/kr/text
-# github.com/rogpeppe/go-internal v1.11.0
-## explicit; go 1.19
+# github.com/rogpeppe/go-internal v1.12.0
+## explicit; go 1.20
 github.com/rogpeppe/go-internal/fmtsort


### PR DESCRIPTION
Also bump the `github.com/rogpeppe/go-internal` indirect dep from 1.11 to 1.12.
Also fix CI by making actions/setup-go fetch the Go version from the go.mod file.