### PR TITLE
chore: aug 2024 maintenance pass

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,6 @@
 			},
 			"extensions": [
 				"davidanson.vscode-markdownlint",
-				"eamodio.gitlens",
 				"golang.go",
 				"redhat.vscode-yaml"
 			]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
@@ -22,13 +22,13 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: go
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Run linter
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
 
   tests:
     name: Run unit tests with the race detector enabled

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,24 +6,15 @@ run:
 linters:
   enable-all: true
   disable:
-    - deadcode # deprecated
     - depguard # enforces that only deps on a whitelist can be used (meant for orgs, not small projects)
-    - exhaustivestruct
+    - execinquery # deprecated
     - exhaustruct
     - forbidigo # we need to use fmt.Print*()
-    - golint # deprecated
     - gomnd
-    - ifshort # deprecated
-    - interfacer # deprecated
-    - maligned # deprecated
     - nolintlint
     - nonamedreturns
-    - nosnakecase # deprecated
     - paralleltest # tests only take 2.5s to run. no need to parallelize
-    - scopelint # deprecated
-    - structcheck # deprecated
     - testpackage
-    - varcheck # deprecated
     - varnamelen # makes bad suggestions
     - wsl
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,7 @@
 {
     "recommendations": [
         "davidanson.vscode-markdownlint",
-        "eamodio.gitlens",
         "golang.go",
-        "redhat.vscode-yaml",
+        "redhat.vscode-yaml"
     ]
 }

--- a/args_test.go
+++ b/args_test.go
@@ -389,7 +389,7 @@ func TestArgNames(t *testing.T) {
 		t.Fatalf("\ngot:  %#v\nwant: %#v", got, want)
 	}
 
-	for i := 0; i < len(got); i++ {
+	for i := range got {
 		if got[i] != want[i] {
 			t.Fatalf("\ngot:  %#v\nwant: %#v", got, want)
 		}
@@ -481,7 +481,7 @@ func TestFormatArgs(t *testing.T) {
 			t.Fatalf("\nTEST %d\ngot:  %s\nwant: %s", tc.id, got, tc.want)
 		}
 
-		for i := 0; i < len(got); i++ {
+		for i := range got {
 			if got[i] != tc.want[i] {
 				t.Fatalf("\nTEST %d\ngot:  %s\nwant: %s", tc.id, got, tc.want)
 			}
@@ -531,7 +531,7 @@ func TestPrependArgName(t *testing.T) {
 			t.Fatalf("\nprependArgName(%v, %v)\ngot:  %v\nwant: %v", tc.names, tc.values, got, tc.want)
 		}
 
-		for i := 0; i < len(got); i++ {
+		for i := range got {
 			if got[i] != tc.want[i] {
 				t.Fatalf("\nprependArgName(%v, %v)\ngot:  %v\nwant: %v", tc.names, tc.values, got, tc.want)
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ryboe/q
 
-go 1.22
+go 1.23
 
 require github.com/kr/pretty v0.3.1
 

--- a/logger.go
+++ b/logger.go
@@ -73,7 +73,8 @@ func (l *logger) shouldPrintHeader(funcName, file string) bool {
 // flush writes the logger's buffer to disk.
 func (l *logger) flush() (err error) {
 	path := filepath.Join(os.TempDir(), "q")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	const userRW = 0o600
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, userRW)
 	if err != nil {
 		return fmt.Errorf("failed to open %q: %w", path, err)
 	}


### PR DESCRIPTION
* remove gitlens from list of recommended extensions
* update golangci-lint action
* update codeql analysis action v2 -> v3
* remove deprecated extensions that were disabled in
  .golangci.yml
* name magic number octal literal in logger.go
* use new for-range over integers syntax
* bump go directive to 1.23
