### PR TITLE
ci: run go vet and staticcheck separately

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,20 +15,17 @@ jobs:
       security-events: write
 
     steps:
-      - name: Checkout repository
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
+      - name: initialize codeql
         uses: github/codeql-action/init@v3
         with:
           languages: go
+          build-mode: autobuild
 
-      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-
-      - name: Perform CodeQL Analysis
+      - name: perform codeql analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,33 +6,52 @@ on:
 
 jobs:
   lint:
-    name: GolangCI Lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Set up go
-        uses: actions/setup-go@v5
+      - name: set up go
+        uses: WillAbides/setup-go-faster@v1
         with:
           go-version-file: go.mod
-      - name: Run linter
+      - name: lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
 
-  tests:
-    name: Run unit tests with the race detector enabled
+  check:
+    name: go vet
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Set up go
-        uses: actions/setup-go@v5
+      - name: set up go
+        uses: WillAbides/setup-go-faster@v1
         with:
           go-version-file: go.mod
-      - name: Run unit tests
+      - name: run go vet
+        run: go vet ./...
+      - name: run staticcheck
+        uses: dominikh/staticcheck-action@v1
+        with:
+          version: latest
+
+  tests:
+    name: run unit tests with the race detector enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: set up go
+        uses: WillAbides/setup-go-faster@v1
+        with:
+          go-version-file: go.mod
+      - name: run unit tests
         run: go test -v -race ./...

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
           version: latest
 
   check:
-    name: go vet
+    name: go vet and staticcheck
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
@@ -42,7 +42,7 @@ jobs:
           version: latest
 
   tests:
-    name: run unit tests with the race detector enabled
+    name: unit tests with race detector enabled
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,11 +9,14 @@ linters:
     - depguard # enforces that only deps on a whitelist can be used (meant for orgs, not small projects)
     - execinquery # deprecated
     - exhaustruct
+    - exportloopref # deprecated
     - forbidigo # we need to use fmt.Print*()
     - gomnd
-    - nolintlint
-    - nonamedreturns
+    - govet # we run the official go vet separately
+    - nolintlint # we do occasionally need to suppress linter false positives
+    - nonamedreturns # named returns often help readability
     - paralleltest # tests only take 2.5s to run. no need to parallelize
+    - staticcheck # dominickh doesn't recommend running staticcheck as part of golangci-lint, so we run Real Staticcheck™ separately
     - testpackage
     - varnamelen # makes bad suggestions
     - wsl

--- a/args_test.go
+++ b/args_test.go
@@ -167,9 +167,11 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 		},
 	}
 
+	// We can test both exprToString() and argName() with the test cases above.
 	for _, tc := range testCases {
 		// test exprToString()
 		testName := fmt.Sprintf("exprToString(%T)", tc.arg)
+		// nolint: thelper
 		t.Run(testName, func(t *testing.T) {
 			if _, ok := tc.arg.(*ast.Ident); ok {
 				return
@@ -182,6 +184,7 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 
 		// test argName()
 		testName = fmt.Sprintf("argName(%T)", tc.arg)
+		// nolint: thelper
 		t.Run(testName, func(t *testing.T) {
 			if got := argName(tc.arg); got != tc.want {
 				t.Fatalf("\ngot:  %s\nwant: %s", got, tc.want)

--- a/args_test.go
+++ b/args_test.go
@@ -74,122 +74,6 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 		},
 		{
 			id: 8,
-			arg: &ast.CallExpr{
-				Fun: &ast.Ident{
-					NamePos: 30,
-					Name:    "foo",
-					Obj: &ast.Object{
-						Kind: 5,
-						Name: "foo",
-						Decl: &ast.FuncDecl{
-							Doc:  nil,
-							Recv: nil,
-							Name: &ast.Ident{
-								NamePos: 44,
-								Name:    "foo",
-								Obj:     &ast.Object{},
-							},
-							Type: &ast.FuncType{
-								Func: 39,
-								Params: &ast.FieldList{
-									Opening: 47,
-									List:    nil,
-									Closing: 48,
-								},
-								Results: &ast.FieldList{
-									Opening: 0,
-									List: []*ast.Field{
-										{
-											Doc:   nil,
-											Names: nil,
-											Type: &ast.Ident{
-												NamePos: 50,
-												Name:    "int",
-												Obj:     nil,
-											},
-											Tag:     nil,
-											Comment: nil,
-										},
-									},
-									Closing: 0,
-								},
-							},
-							Body: &ast.BlockStmt{
-								Lbrace: 54,
-								List: []ast.Stmt{
-									&ast.ReturnStmt{
-										Return: 57,
-										Results: []ast.Expr{
-											&ast.BasicLit{ValuePos: 64, Kind: 5, Value: "123"},
-										},
-									},
-								},
-								Rbrace: 68,
-							},
-						},
-						Data: nil,
-						Type: nil,
-					},
-				},
-				Lparen:   33,
-				Args:     nil,
-				Ellipsis: 0,
-				Rparen:   34,
-			},
-			want: "foo()",
-		},
-		{
-			id: 9,
-			arg: &ast.IndexExpr{
-				X: &ast.Ident{
-					NamePos: 51,
-					Name:    "a",
-					Obj: &ast.Object{
-						Kind: 4,
-						Name: "a",
-						Decl: &ast.AssignStmt{
-							Lhs: []ast.Expr{
-								&ast.Ident{
-									NamePos: 30,
-									Name:    "a",
-									Obj:     &ast.Object{},
-								},
-							},
-							TokPos: 32,
-							Tok:    47,
-							Rhs: []ast.Expr{
-								&ast.CompositeLit{
-									Type: &ast.ArrayType{
-										Lbrack: 35,
-										Len:    nil,
-										Elt: &ast.Ident{
-											NamePos: 37,
-											Name:    "int",
-											Obj:     nil,
-										},
-									},
-									Lbrace: 40,
-									Elts: []ast.Expr{
-										&ast.BasicLit{ValuePos: 41, Kind: 5, Value: "1"},
-										&ast.BasicLit{ValuePos: 44, Kind: 5, Value: "2"},
-										&ast.BasicLit{ValuePos: 47, Kind: 5, Value: "3"},
-									},
-									Rbrace: 48,
-								},
-							},
-						},
-						Data: nil,
-						Type: nil,
-					},
-				},
-				Lbrack: 52,
-				Index:  &ast.BasicLit{ValuePos: 53, Kind: 5, Value: "1"},
-				Rbrack: 54,
-			},
-			want: "a[1]",
-		},
-		{
-			id: 10,
 			arg: &ast.KeyValueExpr{
 				Key: &ast.Ident{
 					NamePos: 72,
@@ -202,7 +86,7 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 			want: `Greeting: "Hello"`,
 		},
 		{
-			id: 11,
+			id: 9,
 			arg: &ast.ParenExpr{
 				Lparen: 35,
 				X: &ast.BinaryExpr{
@@ -216,7 +100,7 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 			want: "(2 * 3)",
 		},
 		{
-			id: 12,
+			id: 10,
 			arg: &ast.SelectorExpr{
 				X: &ast.Ident{
 					NamePos: 44,
@@ -232,104 +116,7 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 			want: "fmt.Print",
 		},
 		{
-			id: 13,
-			arg: &ast.SliceExpr{
-				X: &ast.Ident{
-					NamePos: 51,
-					Name:    "a",
-					Obj: &ast.Object{
-						Kind: 4,
-						Name: "a",
-						Decl: &ast.AssignStmt{
-							Lhs: []ast.Expr{
-								&ast.Ident{
-									NamePos: 30,
-									Name:    "a",
-									Obj:     &ast.Object{},
-								},
-							},
-							TokPos: 32,
-							Tok:    47,
-							Rhs: []ast.Expr{
-								&ast.CompositeLit{
-									Type: &ast.ArrayType{
-										Lbrack: 35,
-										Len:    nil,
-										Elt: &ast.Ident{
-											NamePos: 37,
-											Name:    "int",
-											Obj:     (*ast.Object)(nil),
-										},
-									},
-									Lbrace: 40,
-									Elts: []ast.Expr{
-										&ast.BasicLit{ValuePos: 41, Kind: 5, Value: "1"},
-										&ast.BasicLit{ValuePos: 44, Kind: 5, Value: "2"},
-										&ast.BasicLit{ValuePos: 47, Kind: 5, Value: "3"},
-									},
-									Rbrace: 48,
-								},
-							},
-						},
-						Data: nil,
-						Type: nil,
-					},
-				},
-				Lbrack: 52,
-				Low:    &ast.BasicLit{ValuePos: 53, Kind: 5, Value: "0"},
-				High:   &ast.BasicLit{ValuePos: 55, Kind: 5, Value: "2"},
-				Max:    nil,
-				Slice3: false,
-				Rbrack: 56,
-			},
-			want: "a[0:2]",
-		},
-		{
-			id: 14,
-			arg: &ast.TypeAssertExpr{
-				X: &ast.Ident{
-					NamePos: 62,
-					Name:    "a",
-					Obj: &ast.Object{
-						Kind: 4,
-						Name: "a",
-						Decl: &ast.ValueSpec{
-							Doc: nil,
-							Names: []*ast.Ident{
-								{
-									NamePos: 34,
-									Name:    "a",
-									Obj:     &ast.Object{},
-								},
-							},
-							Type: &ast.InterfaceType{
-								Interface: 36,
-								Methods: &ast.FieldList{
-									Opening: 45,
-									List:    nil,
-									Closing: 46,
-								},
-								Incomplete: false,
-							},
-							Values:  nil,
-							Comment: nil,
-						},
-						Data: int(0),
-						Type: nil,
-					},
-				},
-				Lparen: 64,
-				Type: &ast.Ident{
-					NamePos: 65,
-					Name:    "string",
-					Obj:     nil,
-				},
-				Rparen: 71,
-			},
-			want: "a.(string)",
-		},
-		{
-			id: 15,
+			id: 11,
 			arg: &ast.UnaryExpr{
 				OpPos: 35,
 				Op:    13,
@@ -338,7 +125,7 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 			want: "-1",
 		},
 		{
-			id: 16,
+			id: 12,
 			arg: &ast.Ident{
 				NamePos: 65,
 				Name:    "string",

--- a/args_test.go
+++ b/args_test.go
@@ -190,6 +190,28 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 	}
 }
 
+// TestArgNames verifies that argNames() is able to find the q.Q() call in the
+// sample text and extract the argument names. For example, if q.q(a, b, c) is
+// in the sample text, argNames() should return []string{"a", "b", "c"}.
+func TestArgNames(t *testing.T) {
+	const filename = "testdata/sample1.go"
+	want := []string{"a", "b", "c", "d", "e", "f", "g"}
+	got, err := argNames(filename, 14)
+	if err != nil {
+		t.Fatalf("argNames: failed to parse %q: %v", filename, err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("\ngot:  %#v\nwant: %#v", got, want)
+		}
+	}
+}
+
 // TestArgNamesBadFilename verifies that argNames() returns an error if given an
 // invalid filename.
 func TestArgNamesBadFilename(t *testing.T) {


### PR DESCRIPTION
* `dominickh`, the author of [`staticcheck`](https://github.com/dominikh/go-tools), doesn't recommend running staticcheck as a part of golangci-lint. Run the real, official `staticcheck` separately.
* run `go vet` separately as well. This way we know we're using the latest official `go vet` tool
* use `autobuild` to set up Go in the CodeQL analysis workflow
* rewrite `TestExtractingArgsFromSourceText` to avoid use of deprecated `ast.Object` type
* use [`WillAbides/setup-go-faster`](https://github.com/WillAbides/setup-go-faster) instead of `actions/setup-go` because it's faster