### PR TITLE
Go 1.24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,6 @@
 					},
 					"ui.completion.usePlaceholders": true,
 					"ui.diagnostic.analyses": {
-						"fieldalignment": true,
 						"nilness": true,
 						"unusedparams": true,
 						"unusedvariable": true,

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,13 +8,13 @@ linters:
   disable:
     - depguard # enforces that only deps on a whitelist can be used (meant for orgs, not small projects)
     - exhaustruct
-    - exportloopref # deprecated
     - forbidigo # we need to use fmt.Print*()
     - govet # we run the official go vet separately
     - nolintlint # we do occasionally need to suppress linter false positives
     - nonamedreturns # named returns often help readability
     - paralleltest # tests only take 2.5s to run. no need to parallelize
     - staticcheck # dominickh doesn't recommend running staticcheck as part of golangci-lint, so we run Real Staticcheck™ separately
+    - tenv # deprecated
     - testpackage
     - varnamelen # makes bad suggestions
     - wsl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,11 +7,9 @@ linters:
   enable-all: true
   disable:
     - depguard # enforces that only deps on a whitelist can be used (meant for orgs, not small projects)
-    - execinquery # deprecated
     - exhaustruct
     - exportloopref # deprecated
     - forbidigo # we need to use fmt.Print*()
-    - gomnd
     - govet # we run the official go vet separately
     - nolintlint # we do occasionally need to suppress linter false positives
     - nonamedreturns # named returns often help readability

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
         },
         "ui.completion.usePlaceholders": true,
         "ui.diagnostic.analyses": {
-            "fieldalignment": true,
             "nilness": true,
             "unusedparams": true,
             "unusedvariable": true,

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require github.com/kr/pretty v0.3.1
 
 require (
 	github.com/kr/text v0.2.0 // indirect
-	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	github.com/rogpeppe/go-internal v1.13.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ryboe/q
 
-go 1.23.0
+go 1.24.0
 
 require github.com/kr/pretty v0.3.1
 

--- a/go.sum
+++ b/go.sum
@@ -5,5 +5,5 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
-github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,6 +4,6 @@ github.com/kr/pretty
 # github.com/kr/text v0.2.0
 ## explicit
 github.com/kr/text
-# github.com/rogpeppe/go-internal v1.12.0
-## explicit; go 1.20
+# github.com/rogpeppe/go-internal v1.13.1
+## explicit; go 1.22
 github.com/rogpeppe/go-internal/fmtsort


### PR DESCRIPTION
- **fix: remove deprecated fieldalignment gopls setting**
- **chore: bump rogpeppe/go-internal**
- **fix: remove execinquery and gomnd from list of disabled linters**
- **feat: bump go directive 1.23 -> 1.24**
