### PR TITLE
feat: go 1.26 update

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,11 +5,7 @@
 	// syscall, and we need to disable the default seccomp profile applied to
 	// docker containers.
 	//   https://github.com/go-delve/delve/blob/master/Documentation/faq.md#how-do-i-use-delve-with-docker
-	"runArgs": [
-		"--cap-add=SYS_PTRACE",
-		"--security-opt",
-		"seccomp=unconfined"
-	],
+	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
 	"customizations": {
 		"vscode": {
 			"settings": {
@@ -26,18 +22,18 @@
 					"formatting.gofumpt": true, // set this instead of go.formatTool
 					"ui.codelenses": {
 						// run govulncheck to check Go code for use of vulnerable funcs. complements go.diagnostic.vulncheck
-						"vulncheck": true
+						"vulncheck": true,
 					},
 					"ui.completion.usePlaceholders": true, // completion text will have placeholders that you can tab through
 					"ui.diagnostic.staticcheck": true, // enable all staticcheck checks
-					"ui.semanticTokens": true // more accurate syntax highlighting
-				}
+					"ui.semanticTokens": true, // more accurate syntax highlighting
+				},
 			},
 			"extensions": [
 				"davidanson.vscode-markdownlint",
 				"golang.go",
-				"redhat.vscode-yaml"
-			]
-		}
-	}
+				"redhat.vscode-yaml",
+			],
+		},
+	},
 }

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,16 +16,16 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       # Initializes the CodeQL tools for scanning.
       - name: initialize codeql
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: go
           build-mode: autobuild
 
       - name: perform codeql analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: set up go
-        uses: WillAbides/setup-go-faster@v1
+        uses: actions/setup-go@v6 # TODO: replace with WillAbides/setup-go-faster@v1 when it's fixed
         with:
           go-version-file: go.mod
       - name: lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: set up go
-        uses: WillAbides/setup-go-faster@v1
+        uses: actions/setup-go@v6 # TODO: replace with WillAbides/setup-go-faster@v1 when it's fixed
         with:
           go-version-file: go.mod
       - name: run go vet
@@ -39,18 +39,21 @@ jobs:
       - name: run staticcheck
         uses: dominikh/staticcheck-action@v1
         with:
-          version: latest
+          # uses setup-go-faster by default, which is currently failing,
+          # so we disable automatic installation of Go and install Go
+          # ourselves with setup-go
+          install-go: false
 
-  tests:
+  test:
     name: unit tests with race detector enabled
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: set up go
-        uses: WillAbides/setup-go-faster@v1
+        uses: actions/setup-go@v6 # TODO: replace with WillAbides/setup-go-faster@v1 when it's fixed
         with:
           go-version-file: go.mod
       - name: run unit tests

--- a/args.go
+++ b/args.go
@@ -128,7 +128,7 @@ func exprToString(arg ast.Expr) string {
 }
 
 // formatArgs converts the given args to pretty-printed, colorized strings.
-func formatArgs(args ...interface{}) []string {
+func formatArgs(args ...any) []string {
 	formatted := make([]string, 0, len(args))
 	for _, a := range args {
 		s := colorize(pretty.Sprint(a), cyan)

--- a/args_test.go
+++ b/args_test.go
@@ -252,17 +252,17 @@ func TestArgWidth(t *testing.T) {
 func TestFormatArgs(t *testing.T) {
 	testCases := []struct {
 		id   int
-		args []interface{}
+		args []any
 		want []string
 	}{
 		{
 			id:   1,
-			args: []interface{}{123},
+			args: []any{123},
 			want: []string{colorize("int(123)", cyan)},
 		},
 		{
 			id:   2,
-			args: []interface{}{123, 3.14, "hello world"},
+			args: []any{123, 3.14, "hello world"},
 			want: []string{
 				colorize("int(123)", cyan),
 				colorize("float64(3.14)", cyan),
@@ -271,14 +271,14 @@ func TestFormatArgs(t *testing.T) {
 		},
 		{
 			id:   3,
-			args: []interface{}{[]string{"goodbye", "world"}},
+			args: []any{[]string{"goodbye", "world"}},
 			want: []string{
 				colorize(`[]string{"goodbye", "world"}`, cyan),
 			},
 		},
 		{
 			id: 4,
-			args: []interface{}{
+			args: []any{
 				[]struct{ a, b int }{
 					{1, 2}, {2, 3}, {3, 4},
 				},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ryboe/q
 
-go 1.25.0
+go 1.26.0
 
 require github.com/kr/pretty v0.3.1
 

--- a/q.go
+++ b/q.go
@@ -27,7 +27,7 @@ var (
 )
 
 // Q pretty-prints the given arguments to the $TMPDIR/q log file.
-func Q(v ...interface{}) {
+func Q(v ...any) {
 	std.mu.Lock()
 	defer std.mu.Unlock()
 


### PR DESCRIPTION
* bump go directive to 1.26.0
* format devcontainer.json
* switch default branch to main
* replace interface{} with any
* ci: replace `setup-go-faster` (broken) action with `setup-go`
* ci: bump versions in GHA workflow jobs
* ci: remove redundant setting of default vars in some jobs