### PR TITLE
fix: make CodeQL workflow target main, not master branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,8 @@ name: CodeQL
 
 on:
   push:
-    branches: [master]
-  schedule:
-    - cron: 37 11 * * 2
+    branches:
+      - main
 
 jobs:
   analyze:


### PR DESCRIPTION
Also stop running it on a schedule. The code changes very little, so there's no need for weekly CodeQL runs.
